### PR TITLE
Morph: Permission migration

### DIFF
--- a/src/clients/permission-service.client.ts
+++ b/src/clients/permission-service.client.ts
@@ -33,16 +33,17 @@ export class PermissionServiceClient {
     console.log(`PermissionServiceClient initialized with baseUrl: ${this.baseUrl}`);
   }
 
-  async hasPermission(subjectId: string, domain: Domain, action: Action): Promise<boolean> {
+  async hasPermission(subjectId: string, domain: Domain, action: Action, tenantId?: string): Promise<boolean> {
     try {
-      console.log(`Checking permission for subjectId: ${subjectId}, domain: ${domain}, action: ${action}`);
+      console.log(`Checking permission for subjectId: ${subjectId}, domain: ${domain}, action: ${action}, tenantId: ${tenantId}`);
       const response = await axios.get<PermissionResponse>(
-        `${this.baseUrl}/permissions/check`,
+        `${this.baseUrl}/permissions/v2/check`,
         {
           params: {
             subjectId,
             domain,
-            action
+            action,
+            tenantId
           }
         }
       );

--- a/src/middleware/identity.provider.ts
+++ b/src/middleware/identity.provider.ts
@@ -7,4 +7,11 @@ export class IdentityProvider {
     console.log(`User ID: ${userId}`);
     return userId || null;
   }
+
+  getTenantId(req: Request): string | null {
+    console.log('Extracting tenant ID from request');
+    const tenantId = req.header('identity-tenant-id');
+    console.log(`Tenant ID: ${tenantId}`);
+    return tenantId || null;
+  }
 }


### PR DESCRIPTION
This PR contains the following modifications:

- AI (anthropic/claude-sonnet-4-20250514):
```
The company is moving to multi-tenant setup. This means we need to re-work how we evaluate permissions. Infra team has already implemented authentication and they add new identity-tenant-id header in the api-gateway.

The owners of permission-service have already implemented a new endpoint /v2/check that can accept tenantId along with existing subjectId.

So now all the other components need to be updated to the new version of permission-service. But all the feature teams are busy with building a new shiny AI integration and can not prioritize this upgrade.

The only hope is you.
```
 (Single file: No)

Generated by Morph.